### PR TITLE
Pass hpcs vars to docker compose

### DIFF
--- a/secure_build_docker.ipynb
+++ b/secure_build_docker.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "Navigate to your terminal tab, and from there, enter the command `ibmcloud login -r YOUR-REGION --sso`, substituting one of the following regions for YOUR-REGION:  `us-east`, `ca-tor`, `br-sau`, `eu-gb`, or `jp-tok` which are for United States (East), Toronto, Canda, Sao Paulo, Brazil, London, England, and Tokyo,Japan respectively.  \n",
     "\n",
-    "For your convenience the proper command for each region is listed. From the four commands listed below, copy the one applicable for your region, and paste it into the terminal tab and run the command:\n",
+    "For your convenience the proper command for each region is listed. From the five commands listed below, copy the one applicable for your region, and paste it into the terminal tab and run the command:\n",
     "\n",
     "`ibmcloud login -r us-east --sso`\n",
     "\n",
@@ -549,7 +549,7 @@
     "\n",
     "The code cell below pipes the output of the _cat_ command to a utility called _jq_ (for _JSON query_) which expects well-formed JSON (JavaScript Object Notation) data. If you made a mistake while updating the file that causes a JSON syntax error, the _jq_ utility will detect it and print an error message.  \n",
     "\n",
-    "If you put in a wrong value that doesn't cause a JSON syntax error, _jq_ will not catch that, so inspect the output of the code cell carefully.  All variables that you are required to change started with _YOUR_, so it isn't a bad idea to look for the word YOUR in the output—you shouldn't find it!"
+    "If you put in a wrong value that doesn't cause a JSON syntax error, _jq_ will not catch that, so inspect the output of the code cell carefully."
    ]
   },
   {
@@ -644,7 +644,7 @@
     "\n",
     "### Step 5.10 Create an environment variable for the vpc\n",
     "\n",
-    "Set you vpc name into an environment variable to reuse it by running the following code block."
+    "Set your vpc name into an environment variable to reuse it by running the following code block."
    ]
   },
   {
@@ -666,7 +666,7 @@
     "\n",
     "### Step 5.11 Create your vpc\n",
     "\n",
-    "This lab uses its own vpc to keep things neat and tidy for the end user. Now it's time to create that vpc and save it's ID into an environment variable"
+    "This lab uses its own vpc to keep things neat and tidy for the end user. Now it's time to create that vpc and save its ID into an environment variable"
    ]
   },
   {
@@ -1541,7 +1541,7 @@
     "\n",
     "### Step 6.4 Check the status of your application image build\n",
     "\n",
-    "Check the status of your build by running the code cell below. You can check it periodically—your build should take about twenty minutes to complete. You can run this code cell periodically, as well as the command in the subsequent code cell (_Step 6.9_) which displays the log messages from the build.  For now, check the status by running the code cell below.  Your build has completed successfully once the output of the code cell has the value of *success* in the *status* field:"
+    "Check the status of your build by running the code cell below. You can check it periodically—your build should take about twenty minutes to complete. You can run this code cell periodically, as well as the command in the subsequent code cell (_Step 6.5_) which displays the log messages from the build.  For now, check the status by running the code cell below.  Your build has completed successfully once the output of the code cell has the value of *success* in the *status* field:"
    ]
   },
   {
@@ -1782,7 +1782,9 @@
     "    ports:\n",
     "      - \"443:443\"\n",
     "    environment:\n",
-    "      - WALLET_NAME:general\n",
+    "      - WALLET_NAME=general\n",
+    "      - ZHSM=\\${ZHSM}\n",
+    "      - APIKEy=\\${APIKEY}\n",
     "EOF"
    ]
   },

--- a/secure_build_docker.ipynb
+++ b/secure_build_docker.ipynb
@@ -1784,7 +1784,7 @@
     "    environment:\n",
     "      - WALLET_NAME=general\n",
     "      - ZHSM=\\${ZHSM}\n",
-    "      - APIKEy=\\${APIKEY}\n",
+    "      - APIKEY=\\${APIKEY}\n",
     "EOF"
    ]
   },


### PR DESCRIPTION
Ensured that the HPCS-related environment variables in the HPCR contract's `env` section are passed correctly to the `docker-compose.yml` that is in the contract's `workload` section.

Also corrected a few minor typos.